### PR TITLE
Rename: CardItem -> LinkCard 컴포넌트 이름 변경

### DIFF
--- a/components/LinkCard.tsx
+++ b/components/LinkCard.tsx
@@ -12,7 +12,7 @@ interface linkDataType {
   createdAt: string;
 }
 
-const CardItem = (info: linkDataType) => {
+const LinkCard = (info: linkDataType) => {
   const [isSubscribed, seIsSubscribed] = useState(false);
   const [isOpen, setIsOpen] = useState(false);
 
@@ -78,4 +78,4 @@ const CardItem = (info: linkDataType) => {
   );
 };
 
-export default CardItem;
+export default LinkCard;


### PR DESCRIPTION
제목과 같습니다 CardItem 너무 추상적이어서 직관적으로 LinkCard라고 바꿨습니다!