### PR TITLE
Fix: LinkCard tailwind 수정, timeAgo 유틸함수 로직변경

### DIFF
--- a/components/Link/LinkCard.tsx
+++ b/components/Link/LinkCard.tsx
@@ -58,7 +58,7 @@ const LinkCard = ({ openEdit, openDelete, info }: LinkCardProps) => {
           alt="링크 미리보기"
           fill
         />
-        {/* isFavoritePage일 때만 즐겨찾기 버튼 렌더링 */}
+        {/* 즐겨찾기 페이지가 아닐 때에는 즐겨찾기 버튼 렌더링x */}
         {!isFavoritePage && (
           <div
             onClick={() => setIsSubscribed(!isSubscribed)}
@@ -94,12 +94,10 @@ const LinkCard = ({ openEdit, openDelete, info }: LinkCardProps) => {
             </div>
           )}
         </div>
-        <div className="text-[black100] text-lg ">
+        <div className="text-black100 y-[42px] line-clamp-2">
           {info.description || "설명"}
         </div>
-        <div className="text-sm text-[black200]">
-          {formattedDate || "2024.11.06"}
-        </div>
+        <div className="text-sm">{formattedDate || "2024.11.06"}</div>
       </section>
     </div>
   );

--- a/util/timAgo.ts
+++ b/util/timAgo.ts
@@ -7,11 +7,13 @@ function timeAgo(createdAt: string): string {
   );
   const minutesDiff = Math.floor(secondsDiff / 60);
   const hoursDiff = Math.floor(minutesDiff / 60);
-  const daysDiff = Math.floor(hoursDiff / 24); //
+  const daysDiff = Math.floor(hoursDiff / 24);
 
-  if (hoursDiff < 1) {
+  if (minutesDiff < 1) {
     return `${secondsDiff}초 전`;
-  } else if (hoursDiff < 24) {
+  } else if (hoursDiff < 1) {
+    return `${minutesDiff}분 전`;
+  } else if (daysDiff < 1) {
     return `${hoursDiff}시간 전`;
   } else {
     return `${daysDiff}일 전`;


### PR DESCRIPTION
- timeAgo 함수, 게시글 등록시간을 현재 시간괍 비교하여 1분 이상 이상 차이가 나면 1분전으로 뜨게 했습니다. (기존에는 기준이 1시간이어서 35분 차이가 나면 2100초전이라고 떴습니다.)
- LinkCard 설명 부분이 2줄 이상 넘어가면 "..." 처리되게 tailwind에 line-camp-2 클래스를 추가했습니다