### PR TITLE
Refactor: 토큰 만료 시, 재로그인을 위한 요청 인터럽트 생성

### DIFF
--- a/lib/api/axiosInstanceApi.ts
+++ b/lib/api/axiosInstanceApi.ts
@@ -2,15 +2,11 @@ import axios from "axios";
 
 const axiosInstance = axios.create({
   baseURL: process.env.NEXT_PUBLIC_API_URL || "http://localhost:3000",
-  timeout: 10000,
-  withCredentials: true,
 });
 
 export const proxy = axios.create({
   // 배포 이후에는 배포된 URL로 변경해야 함.
   baseURL: "http://localhost:3000",
-  timeout: 10000,
-  withCredentials: true,
 });
 
 proxy.interceptors.response.use(

--- a/lib/api/axiosInstanceApi.ts
+++ b/lib/api/axiosInstanceApi.ts
@@ -13,4 +13,15 @@ export const proxy = axios.create({
   withCredentials: true,
 });
 
+proxy.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    if (error.response?.status === 401) {
+      alert("세션이 만료되었습니다. 다시 로그인해주세요.");
+      window.location.href = "/login";
+    }
+    return Promise.reject(error);
+  }
+);
+
 export default axiosInstance;

--- a/store/useAuthStore.tsx
+++ b/store/useAuthStore.tsx
@@ -22,75 +22,68 @@ interface AuthStore {
   logout: () => Promise<void>;
 }
 
-const useAuthStore = create<AuthStore>()(
-  persist(
-    (set) => ({
-      user: null,
-      isLoggedIn: false,
+const useAuthStore = create<AuthStore>()((set) => ({
+  user: null,
+  isLoggedIn: false,
 
-      checkLogin: async () => {
-        try {
-          const response = await proxy.get("/api/auth/sign-check");
-          if (response.data.isLoggedIn) {
-            const userInfo = await getUserInfo();
-            if (userInfo) {
-              set({ isLoggedIn: true, user: userInfo });
-            }
-          } else {
-            set({ isLoggedIn: false, user: null });
-          }
-        } catch (error) {
-          console.error("로그인 상태 확인 중 오류 발생", error);
-          set({ isLoggedIn: false, user: null });
+  checkLogin: async () => {
+    try {
+      const response = await proxy.get("/api/auth/sign-check");
+      if (response.data.isLoggedIn) {
+        const userInfo = await getUserInfo();
+        if (userInfo) {
+          set({ isLoggedIn: true, user: userInfo });
         }
-      },
-
-      login: async (body) => {
-        try {
-          const { email, password } = body;
-          const response = await postSignIn({ email, password });
-          if (response) {
-            const userInfo = await getUserInfo();
-            if (userInfo) {
-              set({ isLoggedIn: true, user: userInfo });
-              return true;
-            }
-          }
-        } catch (error) {
-          console.error("로그인 중 에러가 발생했습니다", error);
-        }
-        return false;
-      },
-
-      SNSLogin: async (provider, body) => {
-        try {
-          const response = await postEasySignIn(provider, body);
-          if (response) {
-            const userInfo = await getUserInfo();
-            if (userInfo) {
-              set({ isLoggedIn: true, user: userInfo });
-              return true;
-            }
-          }
-        } catch (error) {
-          console.error("소셜 로그인 중 에러가 발생했습니다.", error);
-        }
-        return false;
-      },
-
-      logout: async () => {
-        try {
-          await proxy.post("/api/auth/sign-out");
-          set({ user: null, isLoggedIn: false });
-        } catch (error) {
-          console.error("로그아웃 중 에러가 발생했습니다.", error);
-        }
-      },
-    }),
-    {
-      name: "auth-storage",
+      } else {
+        set({ isLoggedIn: false, user: null });
+      }
+    } catch (error) {
+      console.error("로그인 상태 확인 중 오류 발생", error);
+      set({ isLoggedIn: false, user: null });
     }
-  )
-);
+  },
+
+  login: async (body) => {
+    try {
+      const { email, password } = body;
+      const response = await postSignIn({ email, password });
+      if (response) {
+        const userInfo = await getUserInfo();
+        if (userInfo) {
+          set({ isLoggedIn: true, user: userInfo });
+          return true;
+        }
+      }
+    } catch (error) {
+      console.error("로그인 중 에러가 발생했습니다", error);
+    }
+    return false;
+  },
+
+  SNSLogin: async (provider, body) => {
+    try {
+      const response = await postEasySignIn(provider, body);
+      if (response) {
+        const userInfo = await getUserInfo();
+        if (userInfo) {
+          set({ isLoggedIn: true, user: userInfo });
+          return true;
+        }
+      }
+    } catch (error) {
+      console.error("소셜 로그인 중 에러가 발생했습니다.", error);
+    }
+    return false;
+  },
+
+  logout: async () => {
+    try {
+      await proxy.post("/api/auth/sign-out");
+      set({ user: null, isLoggedIn: false });
+    } catch (error) {
+      console.error("로그아웃 중 에러가 발생했습니다.", error);
+    }
+  },
+}));
 
 export default useAuthStore;


### PR DESCRIPTION
## 📊 작업내용 

- **Access Token 사용 흐름**
    - 로그인을 하면 서버에서 **accessToken**을 발급받고, 이를 **쿠키**에 저장합니다.
    - 이후 클라이언트에서 API 요청 시, 쿠키에 저장된 **accessToken**을 사용해 서버에 요청을 보냅니다.
- **Access Token 만료 시 처리**
    - 토큰이 만료되면, 클라이언트는 이를 인지하지 못하고 여전히 만료된 **accessToken**으로 요청을 보내게 됩니다.
    - 서버는 만료된 토큰으로 인한 요청에 대해 **401 Unauthorized** 응답을 반환합니다.
- **401 응답 처리**
    - 클라이언트에서는 **401 Unauthorized** 응답을 받으면 토큰이 만료되었다고 판단합니다.
    - 이 시점에서 사용자에게 재로그인을 요청할 수 있습니다.
    - 클라이언트는 로그인 페이지로 리다이렉트하여, 사용자가 다시 로그인을 하면 새로운 **accessToken**을 발급받아 쿠키를 갱신하게 됩니다.